### PR TITLE
ImageConverter.outData() must return shared instance. #1046

### DIFF
--- a/src/Frame.cpp
+++ b/src/Frame.cpp
@@ -1,6 +1,6 @@
 /******************************************************************************
     QtAV:  Multimedia framework based on Qt and FFmpeg
-    Copyright (C) 2012-2016 Wang Bin <wbsecg1@gmail.com>
+    Copyright (C) 2012-2018 Wang Bin <wbsecg1@gmail.com>
 
 *   This file is part of QtAV
 
@@ -57,6 +57,11 @@ int Frame::bytesPerLine(int plane) const
 QByteArray Frame::frameData() const
 {
     return d_func()->data;
+}
+
+int Frame::dataAlignment() const
+{
+    return d_func()->data_align;
 }
 
 QByteArray Frame::data(int plane) const

--- a/src/ImageConverter.cpp
+++ b/src/ImageConverter.cpp
@@ -46,7 +46,7 @@ ImageConverter::~ImageConverter()
 QByteArray ImageConverter::outData() const
 {
     DPTR_D(const ImageConverter);
-    return QByteArray::fromRawData(d.data_out.constData()+d.out_offset, d.data_out.size() - d.out_offset);
+    return d.data_out;
 }
 
 bool ImageConverter::check() const
@@ -216,8 +216,8 @@ bool ImageConverter::prepareData()
     const int nb_planes = qMax(av_pix_fmt_count_planes(d.fmt_out), 0);
     d.bits.resize(nb_planes);
     d.pitchs.resize(nb_planes);
-    // alignment is 16. sws in ffmpeg is 16, libav10 is 8
-    const int kAlign = 16;
+    // alignment is 16. sws in ffmpeg is 16, libav10 is 8. if not aligned sws will print warnings and go slow code paths
+    const int kAlign = DataAlignment;
     AV_ENSURE(av_image_fill_linesizes((int*)d.pitchs.constData(), d.fmt_out, kAlign > 7 ? FFALIGN(d.w_out, 8) : d.w_out), false);
     for (int i = 0; i < d.pitchs.size(); ++i)
         d.pitchs[i] = FFALIGN(d.pitchs[i], kAlign);

--- a/src/ImageConverter.h
+++ b/src/ImageConverter.h
@@ -1,6 +1,6 @@
 /******************************************************************************
     ImageConverter: Base class for image resizing & color model convertion
-    Copyright (C) 2012-2016 Wang Bin <wbsecg1@gmail.com>
+    Copyright (C) 2012-2018 Wang Bin <wbsecg1@gmail.com>
     
 *   This file is part of QtAV
 
@@ -35,9 +35,12 @@ class ImageConverter //export is not needed
 {
     DPTR_DECLARE_PRIVATE(ImageConverter)
 public:
+    enum { DataAlignment = 16 };
+
     ImageConverter();
     virtual ~ImageConverter();
 
+    // the real data starts with DataAlignment (16bit) aligned address
     QByteArray outData() const;
     // return false if i/o format not supported, or size is not valid.
     // TODO: use isSupported(i/o format);

--- a/src/QtAV/Frame.h
+++ b/src/QtAV/Frame.h
@@ -1,6 +1,6 @@
 /******************************************************************************
     QtAV:  Multimedia framework based on Qt and FFmpeg
-    Copyright (C) 2012-2016 Wang Bin <wbsecg1@gmail.com>
+    Copyright (C) 2012-2018 Wang Bin <wbsecg1@gmail.com>
 
 *   This file is part of QtAV
 
@@ -61,7 +61,17 @@ public:
      */
     int bytesPerLine(int plane = 0) const;
     // the whole frame data. may be empty unless clone() or allocate is called
+    // real data starts with dataAlignment() aligned address
     QByteArray frameData() const;
+    int dataAlignment() const;
+    uchar* frameDataPtr(int* size = NULL) const {
+        const int a = dataAlignment();
+        uchar* p = (uchar*)frameData().constData();
+        const int offset = (a - ((uintptr_t)p & (a-1))) & (a-1);
+        if (size)
+            *size = frameData().size() - offset;
+        return p+offset;
+    }
     // deep copy 1 plane data
     QByteArray data(int plane = 0) const;
     uchar* bits(int plane = 0);

--- a/src/QtAV/VideoFrame.h
+++ b/src/QtAV/VideoFrame.h
@@ -1,6 +1,6 @@
 /******************************************************************************
     QtAV:  Multimedia framework based on Qt and FFmpeg
-    Copyright (C) 2012-2016 Wang Bin <wbsecg1@gmail.com>
+    Copyright (C) 2012-2018 Wang Bin <wbsecg1@gmail.com>
 
 *   This file is part of QtAV
 
@@ -52,7 +52,8 @@ public:
     VideoFrame();
     //must set planes and linesize manually if data is empty
     // must set planes and linesize manually
-    VideoFrame(int width, int height, const VideoFormat& format, const QByteArray& data = QByteArray());
+    // alignment: data ptr alignment
+    VideoFrame(int width, int height, const VideoFormat& format, const QByteArray& data = QByteArray(), int alignment = 1);
     VideoFrame(const QImage& image);
     VideoFrame(const VideoFrame &other);
     ~VideoFrame();

--- a/src/QtAV/private/Frame_p.h
+++ b/src/QtAV/private/Frame_p.h
@@ -1,6 +1,6 @@
 /******************************************************************************
     QtAV:  Multimedia framework based on Qt and FFmpeg
-    Copyright (C) 2012-2016 Wang Bin <wbsecg1@gmail.com>
+    Copyright (C) 2012-2018 Wang Bin <wbsecg1@gmail.com>
 
 *   This file is part of QtAV (from 2013)
 
@@ -36,6 +36,7 @@ class FramePrivate : public QSharedData
 public:
     FramePrivate()
         : timestamp(0)
+        , data_align(1)
     {}
     virtual ~FramePrivate() {}
 
@@ -44,6 +45,7 @@ public:
     QVariantMap metadata;
     QByteArray data;
     qreal timestamp;
+    int data_align;
 };
 
 } //namespace QtAV

--- a/src/VideoCapture.cpp
+++ b/src/VideoCapture.cpp
@@ -1,6 +1,6 @@
 /******************************************************************************
     VideoCapture.cpp: description
-    Copyright (C) 2012-2016 Wang Bin <wbsecg1@gmail.com>
+    Copyright (C) 2012-2018 Wang Bin <wbsecg1@gmail.com>
     
 *   This file is part of QtAV
 
@@ -84,7 +84,9 @@ public:
                 QMetaObject::invokeMethod(cap, "failed");
                 return;
             }
-            if (file.write(frame.frameData()) <= 0) {
+            int sz = 0;
+            const char* data = (const char*)frame.frameDataPtr(&sz);
+            if (file.write(data, sz) <= 0) {
                 qWarning("VideoCapture is failed to write captured frame with original format");
                 QMetaObject::invokeMethod(cap, "failed");
                 file.close();

--- a/src/VideoFrame.cpp
+++ b/src/VideoFrame.cpp
@@ -1,6 +1,6 @@
 /******************************************************************************
     QtAV:  Multimedia framework based on Qt and FFmpeg
-    Copyright (C) 2012-2016 Wang Bin <wbsecg1@gmail.com>
+    Copyright (C) 2012-2018 Wang Bin <wbsecg1@gmail.com>
 
 *   This file is part of QtAV
 
@@ -154,11 +154,12 @@ VideoFrame::VideoFrame()
 {
 }
 
-VideoFrame::VideoFrame(int width, int height, const VideoFormat &format, const QByteArray& data)
+VideoFrame::VideoFrame(int width, int height, const VideoFormat &format, const QByteArray& data, int alignment)
     : Frame(new VideoFramePrivate(width, height, format))
 {
     Q_D(VideoFrame);
     d->data = data;
+    d->data_align = alignment;
 }
 
 VideoFrame::VideoFrame(const QImage& image)
@@ -353,7 +354,7 @@ QImage VideoFrame::toImage(QImage::Format fmt, const QSize& dstSize, const QRect
     VideoFrame f(to(VideoFormat(VideoFormat::pixelFormatFromImageFormat(fmt)), dstSize, roi));
     if (!f)
         return QImage();
-    QImage image((const uchar*)f.frameData().constData(), f.width(), f.height(), f.bytesPerLine(0), fmt);
+    QImage image(f.frameDataPtr(), f.width(), f.height(), f.bytesPerLine(0), fmt);
     return image.copy();
 }
 
@@ -395,7 +396,7 @@ VideoFrame VideoFrame::to(const VideoFormat &fmt, const QSize& dstSize, const QR
         qWarning() << "VideoFrame::to error: " << format() << "=>" << fmt;
         return VideoFrame();
     }
-    VideoFrame f(w, h, fmt, conv.outData());
+    VideoFrame f(w, h, fmt, conv.outData(), ImageConverter::DataAlignment);
     f.setBits(conv.outPlanes());
     f.setBytesPerLine(conv.outLineSizes());
     if (fmt.isRGB()) {


### PR DESCRIPTION
several apis are added, to avoid deep copy